### PR TITLE
Ignoring failed child processes

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -1,4 +1,4 @@
-params.contVers = '1.0.2'
+params.contVers = '1.0.3'
 
 manifest.defaultBranch = 'main'
 
@@ -23,6 +23,8 @@ profiles {
     params.contPfx = 'docker://'
 
     process {
+      errorStrategy = 'ignore'
+
       executor = 'slurm'
       queue    = 'short'
       cpus     = 1


### PR DESCRIPTION
O2 runs will ignore failed child processes, instead of terminating the parent process.
