### PR TITLE
Improved Nextflow wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,4 @@ jobs:
         run: ./nextflow main.nf --in genesets --cell-list cl.txt -c custom.config
       - name: Show results
         run: |
-          cat results/apoptosis-auc.csv
-          cat results/pi3k-auc.csv
+          cat results.csv

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ nextflow pull labsyspharm/brca-profiling
 nextflow run labsyspharm/brca-profiling --in genesets
 ```
 
-The script will generate a `results/` directory and populate it with AUC values from evaluating each signature against each drug.
-The output directory can be controlled with `--out`, e.g.,
+The script will evaluate all signatures in the input directory against all drugs and write the resulting AUC values to `results.csv` by default.
+The output filename can be controlled with `--out`, e.g.,
 
 ```
-nextflow run labsyspharm/brca-profiling --in genesets --out /path/to/results
+nextflow run labsyspharm/brca-profiling --in genesets --out my_output.csv
 ```
 
 Signatures can be evaluated on a subset of cell lines. Make a `cl.txt` file that lists which cell lines should be considered (one per line), then feed it to the script with `--cell-list`:

--- a/nextflow.config
+++ b/nextflow.config
@@ -23,13 +23,16 @@ profiles {
     params.contPfx = 'docker://'
 
     process {
-      errorStrategy = 'ignore'
+      errorStrategy = 'retry'
+      maxRetries    = 5
 
-      executor = 'slurm'
-      queue    = 'short'
-      cpus     = 1
-      time     = '6h'
-      memory   = '1GB'
+      withName:accuracy {
+        executor = 'slurm'
+        queue    = 'short'
+        cpus     = 1
+        time     = '6h'
+        memory   = '1GB'
+      }
     }
   }
 }


### PR DESCRIPTION
* The Nextflow wrapper will now aggregate all AUC values from all signatures-by-drugs evaluations into a single `results.csv` file.
* The wrapper will automatically relaunch failed jobs, terminating after five failed attempts.
* Only `accuracy` evaluations will now be submitted via SLURM. Background set generation will now be done on the same node as the parent Nextflow process, removing substantial overhead.